### PR TITLE
Support Twitter Image Upload

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -2518,7 +2518,8 @@ Models.register({
       description = joinText([ps.item, ps.description], "\n");
     }
     if (ps.upload) {
-      description = joinText([ps.description, ps.page, ps.pageUrl, ps.body], "\n");
+      description = joinText([ps.description, ps.page, ps.pageUrl,
+        (ps.body) ? '"' + ps.body + '"' : ''], "\n");
     }
 
     var spar = [];


### PR DESCRIPTION
Change a tag to two spaces in Google+ model as others

Twitter の画像アップーロードのサポートとタブのところをスペースに直しておきました。

なお、簡単にするために、Twitter 内に getBinaryStringFromFile を作りましたが、
適当に直して下さいｗ すみません。
