### PR TITLE
Google+ の internal API の変更に伴う修正

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -982,11 +982,12 @@ Extractors.register([
       var id   = this.getActivityId(ctx);
       return request(url + '?' + queryString({
         updateId : id,
-        hl       : 'en'
+        hl       : 'en',
+        rt       : 'j'
       })).addCallback(function(res) {
         var data = res.responseText.substr(5).replace(/(\\n|\n)/g, '');
         var data = MochiKit.Base.evalJSON(data);
-        data = self.getDataByKey([data], 'os.u');
+        data = self.getDataByKey(data[0], 'os.u');
         if (!data) return null;
         item = data[1];
 


### PR DESCRIPTION
Google+ の internal API の一部が仕様変更（バグフィックス？）になったようなので、対応。
Dashboardでの個別ポストの情報取得に失敗していたのを修正しました。
よろしくお願いします。

PS:
殆ど使われて無いみたいですがｗ
