### PR TITLE
fix a bug that a privacy setting in Pinboard is ignored

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -802,16 +802,17 @@ Models.register({
       });
     }).addCallback(function(res) {
       var form = formContents(res.responseText, true);
+      var content = {
+        title       : ps.item,
+        url         : ps.itemUrl,
+        description : joinText([ps.body, ps.description], ' ', true),
+        tags        : joinText(ps.tags, ' '),
+      };
+      if (ps.private || form.private) {
+        content.private = 'on';
+      }
       return request('https://pinboard.in/add', {
-        sendContent : update(form, {
-          title       : ps.item,
-          url         : ps.itemUrl,
-          description : joinText([ps.body, ps.description], ' ', true),
-          tags        : joinText(ps.tags, ' '),
-          private     :
-            (ps.private == null)? form.private :
-            (ps.private)? 'on' : '',
-        }),
+        sendContent : update(form, content),
       });
     });
   },


### PR DESCRIPTION
Pinboardのプライバシー設定で、「新規ブックマークをデフォルトで非公開にする」を無効にしているにもかかわらずprivateでpostされてしまうので修正してみました。
privateという名前のパラメータが含まれていると、その中身に関係なくprivateなpostとみなされてしまうようです。
