### PR TITLE
Fixed a video post from Google+ to Tumblr

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -649,7 +649,7 @@ Extractors.register([
               type        : 'video',
               item        : attachment[3],
               itemUrl     : ctx.href = attachment[24][1],
-              body        : attachment[21]
+              body        : attachment[5] && attachment[5][1]
             });
           }
           else if ((attachment[24][4] === 'image')


### PR DESCRIPTION
Google+ から Tumblr への Reblog で Video が上手く投稿出来なくなっていたので修正しました。
12/22/2011 の私の修正がまずかったです。なぜそうしたのか忘れてしまいましたが。。。
