### PR TITLE
Fixed the default option on disable.

### DIFF
--- a/src/lib/popup.js
+++ b/src/lib/popup.js
@@ -524,7 +524,7 @@ function Streams(posters) {
   if (streams) {
     $D(selectBox);
     selectBox.appendChild(
-      $N('option', {value : ''}, 'Select Google+ Stream (or same as last one)')
+      $N('option', {value : '', selected : 'selected'}, 'Select Google+ Stream (or same as last one)')
     );
     for (var i = 0, len = streams.presets.length ; i < len ; i++) {
       var preset = streams.presets[i];


### PR DESCRIPTION
Google+ がデフォルトの投稿先に選択されてない（緑のチェックになっていない）場合に、
選択ボックス内のOptionが常にOptGroupの先頭になってしまっていました。
Chromeのレンダリングの問題でしょうか？よくわかりません。

強制的に先頭をselectedにしました。

更新直後で申し訳ありませんが、よろしくお願いします。
