### PR TITLE
Add Photo-Flikr extractor

### DIFF
--- a/src/lib/menu.js
+++ b/src/lib/menu.js
@@ -81,6 +81,18 @@
     }
   });
   chrome.contextMenus.create({
+    title: 'Photo - Flickr',
+    contexts: ['all'],
+    parentId: id,
+    documentUrlPatterns: ['http://www.flickr.com/photos/*/*/*'],
+    onclick: function(info, tab) {
+      chrome.tabs.sendRequest(tab.id, {
+        request: 'contextMenusImage',
+        content: info
+      });
+    }
+  });
+  chrome.contextMenus.create({
     title: 'Photo - Capture',
     contexts: ['all'],
     parentId: id,

--- a/src/lib/popup.js
+++ b/src/lib/popup.js
@@ -382,7 +382,7 @@ function Pic(ps, toggle) {
   this.pic = $('pic');
   this.url = ps.itemUrl || '';
   this.pic.appendChild(this.image = $N('img', {
-    'src': ps.fileEntry || ps.itemUrl,
+    'src': ps.fileEntry || ps.thumbnailUrl || ps.itemUrl,
     'alt': ps.item,
     'title': ps.item,
     'class': 'photo_image',
@@ -399,7 +399,9 @@ function Pic(ps, toggle) {
       this.setAttribute('style', 'height:300px !important;width:'+(height/300*width)+' !important;');
       this.setAttribute('style', 'height:300px !important;width:'+(height/300*width)+' !important;');
     }
-    self.size.appendChild($T(width + ' × ' + height));
+    var w = ps.originalWidth || width;
+    var h = ps.originalHeight || height;
+    self.size.appendChild($T(w + ' × ' + h));
     wait(0).addCallback(function(){
       Form.resize();
     });


### PR DESCRIPTION
FlickrのPhoto対応を追加しました。
- Flickr用のExtractorを追加
- Flickrサイト上でのコンテキストメニューの追加
- APIを使って最大サイズの画像をReblogしようとすると、quick post formでのサムネイルにその画像を使うため表示に時間が掛かるので、サムネイル用URL(ps.thumbnailUrl)とReblogする画像のサイズ(ps.originalWidth, ps.originalHeight)を追加

よろしくお願いします。
