### PR TITLE
Revised the login check strings for Twitter

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -1703,7 +1703,7 @@ Models.register({
     var self = this;
     return request(this.URL + '/settings/account').addCallback(function(res) {
       var html = res.responseText;
-      if (~html.indexOf('class="signin"﻿'))
+      if (~html.indexOf('class="signin"'))
         throw new Error(chrome.i18n.getMessage('error_notLoggedin', self.name));
 
       return {


### PR DESCRIPTION
HTML(CSS)が変わったためか、ログインチェックが出来なくなり、常に「Twitter にログインしていません。」になってしまいました。
チェック方法を Tombloo に合わせて変更しました。
また、URL も新しいものに変更しました。
よろしくお願いします。
