### PR TITLE
chrome.webRequestを使って画像のリダイレクト先を調べるように

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -299,10 +299,8 @@ Tumblr.Regular = {
 
 Tumblr.Photo = {
   convertToFormAsync : function(ps){
-    // Tumblrのバグで画像がリダイレクトすると投稿できないので，予めリダイレクト先を調べておく
     var ret = new Deferred();
-    function callback(res) {
-      var finalurl = res.responseText;
+    function callback(finalurl) {
 
       var form = {
         'post[type]'  : ps.type,
@@ -316,16 +314,14 @@ Tumblr.Photo = {
       ps.file ? (form['images[o1]'] = ps.file) : (form['photo_src'] = finalurl);
       ret.callback(form);
     }
+
     if (ps.itemUrl) {
-      request('http://finalurl.appspot.com/api', {
-        queryString: {
-          url: ps.itemUrl
-        },
-        method: 'GET'
-      }).addCallback(callback);
+      // Tumblrのバグで画像がリダイレクトすると投稿できないので，予めリダイレクト先を調べておく
+      getFinalUrl(ps.itemUrl).addCallback(callback);
     } else {
-      setTimeout(callback, 0, {});
+      setTimeout(callback, 0, null);
     }
+
     return ret;
   }
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1050,3 +1050,58 @@ function getCookies(domain, name) {
   });
   return ret;
 }
+
+/**
+ * URLのリダイレクト先を取得する
+ *
+ * @param {String} url
+ * @return {Deferred} リダイレクト先のURLが返される リダイレイクトしない場合はもとのURL
+ */
+var getFinalUrl = (function() {
+  var redirects = {};
+  var threads = 0;
+
+  // リダイレクトを記録しておく
+  chrome.webRequest.onBeforeRedirect.addListener(function(detail) {
+    redirects[detail.url] = detail.redirectUrl;
+  }, {
+    urls: [
+      "http://*/*",
+      "https://*/*",
+    ],
+  }, []);
+
+  // 暇そうなときにキャッシュ削除
+  setInterval(function() {
+    if (threads == 0) {
+      redirects = {};
+    }
+  }, 60 * 1000);
+
+  return function getFinalUrl(url) {
+    var self = this;
+    var ret = new Deferred();
+
+    // キャッシュにあればすぐに返す
+    if (redirects[url]) {
+      setTimeout(function() {
+        ret.callback(redirects[url]);
+      }, 0, {});
+      return ret;
+    }
+
+    // URLにリクエスト送って調べる
+    threads++;
+    request(url, {
+      method: 'HEAD'
+    }).addBoth(function() {
+      threads--;
+      if (redirects[url]) {
+        ret.callback(redirects[url]);
+      } else {
+        ret.callback(url);
+      }
+    });
+    return ret;
+  };
+})();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,7 +34,7 @@
    "default_locale": "en_US",
    "description": "Yet Another Tombloo on Chromium",
    "name": "Taberareloo",
-   "permissions": [ "http://*/*", "https://*/*", "tabs", "bookmarks", "contextMenus", "cookies", "unlimited_storage", "notifications" ],
+   "permissions": [ "http://*/*", "https://*/*", "tabs", "bookmarks", "contextMenus", "cookies", "unlimited_storage", "notifications", "webRequest" ],
    "version": "2.0.64",
    "incognito": "split"
 }


### PR DESCRIPTION
chrome.webRequestを使うと画像のリダイレクト先を調べられるようだったので，それを使うようにしました．
これまではfinalurl.appspot.comみたいなところにリクエスト投げていましたが，クライアントで完結するほうが良いと思います．
