### PR TITLE
Fixed a bug with ps.body on Gmail

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -3276,7 +3276,7 @@ Models.register({
       description += '<a href="' + ps.pageUrl + '">' + ps.pageUrl + '</a>\n';
     }
     if (ps.body) {
-      description += '<blockquote>' + ps.body + '</blockquote>';
+      description += '<blockquote>' + getFlavor(ps, 'html') + '</blockquote>';
     }
     return description;
   },


### PR DESCRIPTION
選択した文字列をHTMLで渡していませんでした。

こちらで指摘を受けましたので、修正しました。
https://twitter.com/#!/7ouj/status/204206532936732674
