### PR TITLE
2 changes about Twitter Quote extractor

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -254,7 +254,13 @@ Extractors.register([
         };
       } else {
         var elm = ctx.document.querySelector('.tweet-text');
-        var sel = createFlavoredString(elm);
+        var cloneElm = elm.cloneNode(true);
+        $A(cloneElm.getElementsByClassName('tco-ellipsis')).forEach(
+          function(target){
+            target.parentNode.removeChild(target);
+          }
+        );
+        var sel = createFlavoredString(cloneElm);
         res.body = sel.raw;
         res.flavors = {
           html : sel.html


### PR DESCRIPTION
TwitterのQuoteに関するextractorで、2つの変更を行なっています。
1. ツイートに別のツイートのURLが含まれる場合、下にそのツイートが埋め込まれますが、extractorはそれのテキストを取得してしまいます。別のツイートのURLが複数である場合は、最初に埋め込まれたツイートが取得されてしまいました。<br>
   ![screenshot1](http://cache.gyazo.com/ab23e3d5ee5ac4e70e8b79037b58be99.png)
   https://twitter.com/syoichi/status/227379400084172800<br>
   また、「このツイートをサイトに埋め込む」をクリックし、表示されたモードレスダイアログを閉じた後にツイートをポストしようとすると、ツイートがリプライしているツイートである場合、リプライ**されている**ツイートが取得されてしまいます。<br>
   ![screenshot2](http://cache.gyazo.com/ccc24c433c086af40dd5acdab84b2565.png)<br>
   そこで、ツイートを取得する為に使われている古くなったセレクタを削除し、開いているページのツイートが取得されるように修正しました。<br>
   ![screenshot3](http://cache.gyazo.com/f1d47d7de16fd94d507f78fbe6f1cd80.png)
2. TaberarelooではTwitterの仕様とツイートの取得方法により、ツイートに含まれるURLが省略される事なく取得されていますが、その際、省略記号の三点リーダーもそのまま取得してしまいます(省略記号の付いていないURLでも空白が付いてしまう)。<br>
   ![screenshot4](http://cache.gyazo.com/ef20621da78e7b5fe7fb67ce3eba96f2.png)
   https://twitter.com/syoichi/status/225365635205574656<br>
   ユーザーが投稿した本来のツイートに近い形で取得されるのがより望ましいと考え、URLが含まれたツイートを取得する時は、三点リーダーや空白を削除するように変更しました。<br>
   ![screenshot5](http://cache.gyazo.com/fc37730d65fa274eb8a613a730621f2f.png)

不具合及びこの変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 20.0.1132.57、拡張のバージョンは2.0.66( 068f6fbb8a2e25c7429c645cd5fd49c7a7e2c7c2 までの変更を含む)という環境で確認しています。
