### PR TITLE
add whitelist for https check #66

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -90,6 +90,9 @@
   "label_notconvertText": {
     "message": "Not convert long Text post to Link"
   },
+  "label_httpsWhitelist": {
+    "message": "You can register domains of site that you want to allow posting https link."
+  },
   "warning_https": {
     "message": "Https $title$\n    $original$\n    is converted to\n    $modified$",
     "description": "when https link has found",

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -90,6 +90,9 @@
   "label_notconvertText": {
     "message": "長文を含むTextポストをLinkポストに変換しない"
   },
+  "label_httpsWhitelist": {
+    "message": "httpsリンクのポストを許可するサイトのドメインを登録できます。"
+  },
   "warning_https": {
     "message": "Https $title$\n    $original$\n    は\n    $modified$\n    に変換されました。",
     "description": "httpsのリンクが見つかった",

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -77,6 +77,7 @@ connect(document, 'onDOMContentLoaded', document, function(){
   $('label_trimReblogInfo').appendChild($T(chrome.i18n.getMessage('label_trimReblogInfo')));
   $('label_appendContentSource').appendChild($T(chrome.i18n.getMessage('label_appendContentSource')));
   $('label_notconvertText').appendChild($T(chrome.i18n.getMessage('label_notconvertText')));
+  $('label_httpsWhitelist').appendChild($T(chrome.i18n.getMessage('label_httpsWhitelist')));
   $('label_example').appendChild($T(chrome.i18n.getMessage('label_example')));
   $('save').value = chrome.i18n.getMessage('label_save');
 
@@ -155,6 +156,8 @@ connect(document, 'onDOMContentLoaded', document, function(){
   var append_check = new Check('append_content_source', !!Config.entry["append_content_source"]);
   // notconvert to Text
   var notconvert_check = new Check('not_convert_text', !!Config.entry["not_convert_text"]);
+  // whitelist for https check
+  var https_whitelist = new Input('https_whitelist', Config.entry['https_whitelist']);
   // keyconfig
   var keyconfig_check = new Check("keyconfig", !!Config.post['keyconfig']);
   // shortcutkey quick link post
@@ -216,7 +219,8 @@ connect(document, 'onDOMContentLoaded', document, function(){
           'twitter_template' : twittemp.body(),
           'trim_reblog_info'   : reblog_check.body(),
           'append_content_source'   : append_check.body(),
-          'not_convert_text'   : notconvert_check.body()
+          'not_convert_text'   : notconvert_check.body(),
+          'https_whitelist': https_whitelist.body()
         }
       });
       if(!tcheck){

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -647,11 +647,11 @@ function checkHttps(ps) {
       pageFlag = false,
       itemFlag = false,
       m    = null;
-  if (page && (m = page.match(/^https:\/\/[^/]+/))) {
+  if (page && (m = page.match(/^https:\/\/[^/]+/)) && !isWhitelistedSite(page)) {
     pageFlag = true;
     ps.pageUrl = m[0];
   }
-  if (item && (m = item.match(/^https:\/\/[^/]+/))) {
+  if (item && (m = item.match(/^https:\/\/[^/]+/)) && !isWhitelistedSite(item)) {
     itemFlag = true;
     ps.itemUrl = m[0];
   }
@@ -660,6 +660,16 @@ function checkHttps(ps) {
     itemUrl: [itemFlag, item]
   };
   return ps;
+}
+
+function isWhitelistedSite(url) {
+  var https_whitelist = TBRL.config.entry.https_whitelist;
+  if (!https_whitelist) {
+    return false;
+  }
+  var whitelist = https_whitelist.split(/\r?\n/);
+  var urlParser = $N('a', {href: url});
+  return whitelist.indexOf(urlParser.hostname) !== -1;
 }
 
 function getTempFile(ext) {

--- a/src/options.html
+++ b/src/options.html
@@ -249,6 +249,13 @@
       <div class="option">
       <p id="label_notconvertText"></p><input id="not_convert_text_checkbox" type="checkbox" name="not_convert_text">
       </div>
+      <div class="option">
+        <h2>whitelist for https check</h2>
+        <div class="option_line">
+          <p id="label_httpsWhitelist"></p>
+          <textarea id="https_whitelist_input" title="twitter.com&#010;support.twitter.com&#010;..."></textarea>
+        </div>
+      </div>
     </div>
     <div id="about" class="slide">
       <div class="item">

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -188,3 +188,9 @@ table.option_table th {
   border-style: solid !important;
   border-color: #bbb !important;
 }
+
+textarea {
+  max-width: 710px;
+  width: 100%;
+  height: 200px;
+}


### PR DESCRIPTION
#66 を解決する為に、許可したいサイトのドメイン(厳密にはFQDN?)単位でホワイトリストに登録できるように実装してみました。

以下のように、Optionの「エントリ内容/他」の「whitelist for https check」から登録できます。
![screenshot](http://cache.gyazo.com/628ad3481e460b3d123af3e13b90eb9f.png)

この変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 21.0.1180.77、拡張のバージョンは2.0.67( 659f185c9f9ab03e282e8b1fcc5546d081ed60ed までの変更を含む)という環境で確認しています。
