### PR TITLE
2 bugfixes in Browser Action's QuickPostForm

### DIFF
--- a/src/lib/popup.js
+++ b/src/lib/popup.js
@@ -102,7 +102,7 @@ function Form(ps) {
     $("icon_container").appendChild(cancel);
   }
 
-  if ((ps.https.pageUrl[0] || ps.https.itemUrl[0]) && ps.https.pageUrl[1] !== ps.pageUrl) {
+  if ((ps.https.pageUrl[0] || ps.https.itemUrl[0]) && !(isPopup && ps.https.pageUrl[1] === ps.pageUrl)) {
     // pageUrl or itemUrl is https
     var list = [];
     if (ps.https.pageUrl[0]) {


### PR DESCRIPTION
2つの不具合修正を行なっています。
いずれも私の動作テスト不足によるものです。
1. Optionの「デフォルトのポスト先」から、デフォルトで投稿するように設定したサービスがあり、Browser ActionのQuickPostFormでそのサービスの選択を解除してQuickPostFormを閉じて再度開いた場合、その選択の解除が保存されない問題を修正しました。 #124 にてBrowser ActionのQuickPostFormの不具合修正を行った時に気付くべき問題でした。
2. プロトコルがHTTPのサイト上で、HTTPSのリンクをポストしようとすると、QuickPostFormでHTTPSのリンクのポストの許可を求めるwarningが表示されず、URLの変換を行わないようにする事ができない問題を修正しました。この問題は、 2646bbc1a3f3792cce482f1ffaaad326f3b89c57 (#124 の7)のregressionです。HTTPSのリンクのポストを許可したというpermissionのチェックは、Browser ActionのQuickPostFormでのみ行うように改めました。この問題はリリースされた2.0.67に含まれている為、影響は比較的大きいと思われます。申し訳ありません…。

不具合及びこの変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 21.0.1180.77、拡張のバージョンは2.0.67( 659f185c9f9ab03e282e8b1fcc5546d081ed60ed までの変更を含む)という環境で確認しています。
