### PR TITLE
Interval for pin-reblog

### DIFF
--- a/src/lib/userscripts.js
+++ b/src/lib/userscripts.js
@@ -294,7 +294,7 @@ UserScripts.register([
         setTimeout(function(){
           self.notify(target, true);
           self.reblog(target, manually);
-        }, 0);
+        }, returned * 1000);
         if(++returned === len){
           document.removeEventListener(ev_name, callee, false);
           setTimeout(function(){


### PR DESCRIPTION
大量にPinした後にReblogを実行すると投稿エラーが発生するらしいです。
ちょっとインターバルを入れると改善されるみたいですが、完全では無いようです。
念の為、ご報告も兼ねて。
