### PR TITLE
Add web_accessible_resources for Notifications' icon

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -43,6 +43,9 @@
      ],
      "content_security_policy": "sandbox allow-scripts; 'unsafe-eval'"
    },
+   "web_accessible_resources": [
+     "skin/fork64.png"
+   ],
    "icons": {
      "128": "skin/fork128.png",
      "64": "skin/fork64.png",


### PR DESCRIPTION
Notification の ICON が表示されてないので、もしかしたらと思って、
web_accessible_resources に追加したら表示されるようになりました。
