### PR TITLE
Fixed a bug when ps.description is undefined.

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -2823,7 +2823,7 @@ Models.register({
       : succeed(ps.body)).addCallback(function(snippet) {
       ps.body = snippet;
 
-      var description = ps.description;
+      var description = (ps.description == null) ? '' : ps.description;
       if (ps.type === 'regular') {
         description = joinText([ps.item, ps.description], "\n");
       }
@@ -2836,7 +2836,7 @@ Models.register({
 
       var spar = [];
       if (ps.reshare) {
-        description = ps.description;
+        description = (ps.description == null) ? '' : ps.description;
         spar.push(
           description,
           self.getToken(oz),


### PR DESCRIPTION
Tumblr の Dashboard で Pin を使った場合に ps.description が undefined になったようで、
Google+ の投稿時に Google+ 側がエラーで弾いてしまいました。
本体側の変更によるものと思われますが、undefined や null が来た時もエラーを出さないように、
Google+ Model 側にパッチを当てました。
よろしくお願いします。
