### PR TITLE
Drop support for Wassr #135

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -27,8 +27,7 @@ and
 and
 
 +  4u
-+  Clipp
-+  Wassr (these are Japanese Service)
++  Clipp (these are Japanese Service)
 
 and others
 

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -2057,37 +2057,6 @@ Models.register({
 });
 
 Models.register({
-  name : 'Wassr',
-  ICON : 'https://wassr.jp/favicon.ico',
-  LINK : 'https://wassr.jp/',
-  LOGIN_URL : 'https://wassr.jp/',
-
-  check : function(ps){
-    return /regular|photo|quote|link|conversation|video/.test(ps.type) && !ps.file;
-  },
-
-  post : function(ps){
-    return this.addMessage(joinText([ps.item, ps.itemUrl, ps.body, ps.description], ' ', true));
-  },
-
-  addMessage : function(message){
-    var self = this;
-    return request('http://wassr.jp/my/').addCallback(function(res){
-      var doc = createHTML(res.responseText);
-      if($X('id("LoginForm")', doc)[0])
-        throw new Error(chrome.i18n.getMessage('error_notLoggedin', self.name));
-
-      return request('http://wassr.jp/my/status/add', {
-        //redirectionLimit : 0,
-        sendContent : update(formContents($X('id("HeadBox")/descendant::form', doc)[0]), {
-          message : message
-        })
-      });
-    })
-  }
-});
-
-Models.register({
   name: 'Clipp',
   ICON : chrome.extension.getURL('skin/clipp.ico'),
   CLIPP_URL: 'http://clipp.in/',


### PR DESCRIPTION
Wassrのサービス終了を確認しましたので、対応終了の変更を行いました。

> 2012年10月1日をもちまして「Wassr」のすべてのサービスの提供を終了させていただきました。

[「Wassr」サービス終了のお知らせ](http://wassr.jp/)

この変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 22.0.1229.79、拡張のバージョンは2.0.72( 1393429cb91dff9c3da17f8442a90542b43ed42c までの変更を含む)という環境で確認しています。
