### PR TITLE
タグの取得元をPinboardにするとサイドバーの表示形式が変わる

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -892,19 +892,9 @@ Models.register({
   },
 
   getUserTags : function(){
-    var that = this;
-    return succeed().addCallback(function(){
-      return that.getCurrentUser().addCallback(function(username) {
-        return request('https://pinboard.in/u:' + username, {
-          queryString: {
-            mode: 'list',
-            floor: 1
-          }
-        });
-      });
-    }).addCallback(function(res){
-      var doc = createHTML(res.responseText);
-      return $X('id("tag_cloud")//a[contains(@class, "tag")]/text()', doc).map(function(tag) {
+    return request('https://pinboard.in/user_tag_list/').addCallback(function(res){
+      var tags = JSON.parse(res.responseText.replace(/^var\s+usertags\s*=\s*(\[.+\]);$/, '$1'));
+      return tags.map(function(tag){
         return {
           name: tag,
           frequency: 0


### PR DESCRIPTION
Pinboardのタグは https://pinboard.in/u:username?mode=list&floor=1 から取得されるようになっていますが、このURLをGETするとPinboard側の設定が変更されてしまい、サイドバーの表示形式がall tagsに変わってしまいます。
そこで、Pinboardがサイト上でのタグ補完に使っているのと同じデータ (https://pinboard.in/user_tag_list/) を利用するように変更しました。こちらのURLは呼び出しても副作用はなさそうです。

よろしくお願いします。
