### PR TITLE
Twitter is going to change the t.co spec on Feb. 2013.

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -1543,7 +1543,7 @@ Models.register({
       ps = update({}, ps);
       ps.item    = ps.page;
       ps.itemUrl = ps.pageUrl;
-      maxlen -= 21; // reserve for pic.twitter.com
+      maxlen -= 23; // reserve for pic.twitter.com
     }
     if (!template) {
       status = joinText([ps.description, (ps.body)? '"' + ps.body + '"' : '', ps.item, ps.itemUrl], ' ');
@@ -1704,8 +1704,8 @@ Models.register({
 
   getActualLength : function(status) {
     var ret = status.split('\n').map(function (s) {
-      s = s.replace(/(https:\/\/(?:(?:[^ &),]|&amp;)+))/g, '12345678901234567890');
-      return s.replace(/(http:\/\/(?:(?:[^ &),]|&amp;)+))/g, '1234567890123456789');
+      s = s.replace(/(https:\/\/(?:(?:[^ &),]|&amp;)+))/g, '12345678901234567890123');
+      return s.replace(/(http:\/\/(?:(?:[^ &),]|&amp;)+))/g, '1234567890123456789012');
     }).join('\n');
     return ret.length;
   }


### PR DESCRIPTION
Twitter が短縮リンクの仕様を変更、URLつき投稿の最大文字数は2文字減 - Engadget Japanease
http://japanese.engadget.com/2012/12/06/twitter-url-2/

に合わせて変更しました。
