### PR TITLE
Fix for new YouTube style

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -1140,7 +1140,7 @@ Extractors.register([
     name : 'Video - YouTube',
     ICON : 'http://youtube.com/favicon.ico',
     check : function(ctx){
-      if (ctx.href.match(/^http:\/\/.*\.youtube\.com\/watch\.*/)) {
+      if (ctx.href.match(/^https?:\/\/.*\.youtube\.com\/watch\.*/)) {
         return queryHash(createURI(ctx.href).search).v;
       }
       return false;


### PR DESCRIPTION
YouTube Extractorをサイトの変更にあわせて修正しています。その際、もはや動作していないと思われる古いXPathを削除しています。
また、サイトのプロトコルがHTTPSの時でも動作するように変更しています。

この変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 23.0.1271.95、拡張のバージョンは2.0.73( a092072b13b6b6a099654fd718457a254d8b8c7f までの変更を含む)という環境で確認しています。
