### PR TITLE
Fix a bug with HTTPS youtube URL to google+

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -2339,7 +2339,7 @@ Models.register({
 
   sequence : 0,
 
-  YOUTUBE_REGEX : /http:\/\/(?:.*\.)?youtube.com\/watch\?v=([a-zA-Z0-9_-]+)[-_.!~*'()a-zA-Z0-9;\/?:@&=+\$,%#]*/g,
+  YOUTUBE_REGEX : /http(?:s)?:\/\/(?:.*\.)?youtube.com\/watch\?v=([a-zA-Z0-9_-]+)[-_.!~*'()a-zA-Z0-9;\/?:@&=+\$,%#]*/g,
 
   timer : null,
 


### PR DESCRIPTION
かなり小さいバグなんですが、youtube の URL が https の時に、google+ が Video ポストにならないバグを修正しました。
