### PR TITLE
Add Options for sharing Tumblr posts on Twitter and Facebook

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -90,6 +90,12 @@
   "label_notconvertText": {
     "message": "Not convert long Text post to Link"
   },
+  "label_tumblr2twitter": {
+    "message": "Share Tumblr posts on your Twitter"
+  },
+  "label_tumblr2facebook": {
+    "message": "Share Tumblr posts on your Facebook"
+  },
   "warning_https": {
     "message": "Https $title$\n    $original$\n    is converted to\n    $modified$",
     "description": "when https link has found",

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -90,6 +90,12 @@
   "label_notconvertText": {
     "message": "長文を含むTextポストをLinkポストに変換しない"
   },
+  "label_tumblr2twitter": {
+    "message": "Tumblrへの投稿をTwitterでも共有する"
+  },
+  "label_tumblr2facebook": {
+    "message": "Tumblrへの投稿をFacebookでも共有する"
+  },
   "warning_https": {
     "message": "Https $title$\n    $original$\n    は\n    $modified$\n    に変換されました。",
     "description": "httpsのリンクが見つかった",

--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -466,8 +466,8 @@ Extractors.register([
           'post[state]': new String(post.state),
           custom_tweet: '',
           allow_photo_replies: '',
-          send_to_fbog: '',
-          send_to_twitter: ''
+          send_to_fbog: TBRL.config.entry.tumblr2facebook ? 'on' : '',
+          send_to_twitter: TBRL.config.entry.tumblr2twitter ? 'on' : ''
         };
 
         if (post.type === 'photo') {

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -199,8 +199,8 @@ var Tumblr = {
       'is_rich_text[two]': '0',
       'post[state]': '0',
       allow_photo_replies: '',
-      send_to_fbog: '',
-      send_to_twitter: ''
+      send_to_fbog: TBRL.Config.entry.tumblr2facebook ? 'on' : '',
+      send_to_twitter: TBRL.Config.entry.tumblr2twitter ? 'on' : ''
     };
     var that = this;
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -77,6 +77,8 @@ connect(document, 'onDOMContentLoaded', document, function(){
   $('label_trimReblogInfo').appendChild($T(chrome.i18n.getMessage('label_trimReblogInfo')));
   $('label_appendContentSource').appendChild($T(chrome.i18n.getMessage('label_appendContentSource')));
   $('label_notconvertText').appendChild($T(chrome.i18n.getMessage('label_notconvertText')));
+  $('label_tumblr2twitter').appendChild($T(chrome.i18n.getMessage('label_tumblr2twitter')));
+  $('label_tumblr2facebook').appendChild($T(chrome.i18n.getMessage('label_tumblr2facebook')));
   $('label_example').appendChild($T(chrome.i18n.getMessage('label_example')));
   $('save').value = chrome.i18n.getMessage('label_save');
 
@@ -155,6 +157,10 @@ connect(document, 'onDOMContentLoaded', document, function(){
   var append_check = new Check('append_content_source', !!Config.entry["append_content_source"]);
   // notconvert to Text
   var notconvert_check = new Check('not_convert_text', !!Config.entry["not_convert_text"]);
+  // tumblr2twitter
+  var tumblr2twitter = new Check('tumblr2twitter', !!Config.entry["tumblr2twitter"]);
+  // tumblr2facebook
+  var tumblr2facebook = new Check('tumblr2facebook', !!Config.entry["tumblr2facebook"]);
   // keyconfig
   var keyconfig_check = new Check("keyconfig", !!Config.post['keyconfig']);
   // shortcutkey quick link post
@@ -216,7 +222,9 @@ connect(document, 'onDOMContentLoaded', document, function(){
           'twitter_template' : twittemp.body(),
           'trim_reblog_info'   : reblog_check.body(),
           'append_content_source'   : append_check.body(),
-          'not_convert_text'   : notconvert_check.body()
+          'not_convert_text'   : notconvert_check.body(),
+          'tumblr2twitter'   : tumblr2twitter.body(),
+          'tumblr2facebook'   : tumblr2facebook.body()
         }
       });
       if(!tcheck){

--- a/src/options.html
+++ b/src/options.html
@@ -249,6 +249,12 @@
       <div class="option">
       <p id="label_notconvertText"></p><input id="not_convert_text_checkbox" type="checkbox" name="not_convert_text">
       </div>
+      <div class="option">
+      <p id="label_tumblr2twitter"></p><input id="tumblr2twitter_checkbox" type="checkbox" name="tumblr2twitter">
+      </div>
+      <div class="option">
+      <p id="label_tumblr2facebook"></p><input id="tumblr2facebook_checkbox" type="checkbox" name="tumblr2facebook">
+      </div>
     </div>
     <div id="about" class="slide">
       <div class="item">


### PR DESCRIPTION
TaberarelooによってTumblrへ投稿したポストがTwitterやFacebookで共有できない問題に対応する為、設定から共有できるようにしてみました。Tumblrの設定に関するページ(http://www.tumblr.com/blog/USERNAME/settings )でTwitterやFacebookにおいて認証済みである場合に、Taberarelooの設定を有効にすると共有されるようになります。Tumblrの設定ページで共有を有効にしていなくても、Taberarelooの設定が有効になっていれば共有されます。

TwitterやFacebookへ共有するかどうかは、Reblog時に関してはhttp://www.tumblr.com/svc/post/fetch から取得できそうに見えるのですが、共有を有効にしているにもかかわらず、`send_to_fbog`と`send_to_twitter`は`false`となっているようです。
![screenshot](https://f.cloud.github.com/assets/69238/107534/33b55e32-6a2e-11e2-920e-d1f00ed4d7cf.PNG)

TwitterやFacebookへ共有される時の内容は、Twitterに関しては`custom_tweet`で変更可能で、`custom_tweet`が`''`の場合はTumblr側で適切にツイートを設定してくれるようです。ただし、Tumblr上で通常の投稿やReblogを行った場合に共有されるツイートの内容とは微妙に異なるので、あくまで部分的な対応となります。Facebookに関しては、私が確認した限りでは同一の内容で共有されるようでした。

この変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 24.0.1312.56 、拡張のバージョンは2.0.76(865042b0bba725891f4f7ce89fbb5200101174f4 までの変更を含む)という環境で確認しています。
