### PR TITLE
Add Patch File System

### DIFF
--- a/src/lib/menu.js
+++ b/src/lib/menu.js
@@ -176,4 +176,52 @@
       });
     }
   });
+  var patchFileURLs = [
+    'http://*/*.js',
+    'https://*/*.js'
+  ];
+  chrome.contextMenus.create({
+    type: 'separator',
+    contexts: ['all'],
+    parentId: id
+  });
+  var patch_sub_id = chrome.contextMenus.create({
+    title: 'Patch ...',
+    contexts: ['all'],
+    parentId: id
+  });
+  chrome.contextMenus.create({
+    title: 'Install this',
+    contexts: ['page'],
+    parentId: patch_sub_id,
+    documentUrlPatterns: patchFileURLs,
+    onclick: function(info, tab) {
+      Patch.install(info.pageUrl);
+    }
+  });
+  chrome.contextMenus.create({
+    title: 'Uninstall this',
+    contexts: ['page'],
+    parentId: patch_sub_id,
+    documentUrlPatterns: patchFileURLs,
+    onclick: function(info, tab) {
+      Patch.uninstall(info.pageUrl);
+    }
+  });
+  chrome.contextMenus.create({
+    title: 'List',
+    contexts: ['all'],
+    parentId: patch_sub_id,
+    onclick: function(info, tab) {
+      Patch.list();
+    }
+  });
+  chrome.contextMenus.create({
+    title: 'Remove all',
+    contexts: ['all'],
+    parentId: patch_sub_id,
+    onclick: function(info, tab) {
+      Patch.removeAll();
+    }
+  });
 })();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -43,6 +43,7 @@
      ],
      "content_security_policy": "sandbox allow-scripts; script-src 'unsafe-eval'"
    },
+   "content_security_policy": "script-src 'self' filesystem:; object-src 'self'",
    "web_accessible_resources": [
       "styles/dashboard.css",
       "styles/reader.css",


### PR DESCRIPTION
ちょっと思いついたので試してみました。
Background 側だけですが、モデルの追加／変更とかいろいろ出来そうです。

https://github.com/YungSang/patches-for-taberareloo/blob/master/taberareloo.model.googleplus.js
簡単なテスト用パッチも上手く動いてます。

ただ、Uninstall が単なるファイルの削除になっていて、追加したスクリプトを動的に無効にする方法はまだ思いついてません。
今はUninstall後に、Taberarelooを無効／有効で再ロードするか、ブラウザを再起動しないとなりません。

とりあえず、アイデアということで。
