### PR TITLE
Add a bit wait to resize the QuickPostForm properly

### DIFF
--- a/src/lib/popup.js
+++ b/src/lib/popup.js
@@ -428,7 +428,7 @@ function Pic(ps, toggle) {
     var w = ps.originalWidth || width;
     var h = ps.originalHeight || height;
     self.size.appendChild($T(w + ' × ' + h));
-    wait(0).addCallback(function(){
+    wait(0.3).addCallback(function(){
       Form.resize();
     });
   });


### PR DESCRIPTION
最近 QuickPostForm のサイズが変なのが気になったので、いろいろ調べたんですが、
wait を入れた方が良いようです。
