### PR TITLE
Use chrome.windows.create instead of window.open

### DIFF
--- a/src/lib/background.js
+++ b/src/lib/background.js
@@ -251,7 +251,6 @@ var TBRL = {
   Popup: {
     count: 0,
     open: function(tab, ps) {
-      var height = 'height=200';
       var id = 'QuickPost' + (TBRL.Popup.count++);
       var query = queryString({
         'quick': 'true',
@@ -261,11 +260,13 @@ var TBRL = {
         'ps': ps,
         'tab': tab
       };
-      window.open(
-          chrome.extension.getURL('popup.html') + query,
-          id,
-          height +
-          ',width=450,menubar=no,toolbar=no,location=no,status=no,resizable=yes,scrollbars=no');
+      chrome.windows.create({
+        url     : chrome.extension.getURL('popup.html') + query,
+        width   : 450,
+        height  : 200,
+        focused : true,
+        type    : 'popup'
+      });
     },
     defaultSuggester: 'HatenaBookmark',
     tags: null,


### PR DESCRIPTION
https://plus.google.com/109448778834120388056/posts/1qSZQb6kLfY
“ ChromeのTumblr用拡張のTaberareloo、デュアルモニターで使ってるとQuickPostFormが前回の位置を記憶してくれなくて必ずプライマリモニターの左上に飛んでいっちゃうのはどうにかならないのん ”

がちょっと改善されるようです。
