### PR TITLE
Stabilize the position of the popup window

### DIFF
--- a/src/lib/popup.js
+++ b/src/lib/popup.js
@@ -295,7 +295,12 @@ Form.resize = function() {
     var root = document.body;
     var height = root.scrollHeight - window.innerHeight;
     var width  = root.scrollWidth  - window.innerWidth;
-    window.resizeBy(width, height);
+    chrome.windows.getCurrent({}, function(win) {
+      chrome.windows.update(win.id, {
+        width  : win.width + width,
+        height : win.height + height
+      });
+    });
     Form.nowResizing = false;
   } else {
     callLater(0.5, Form.resize);


### PR DESCRIPTION
Popup 側も window.resizeBy では無く、chrome.windows.update にしました。

ちなみに、
Mac ではフォーカスが無い Window でも右クリックから Popup を出せますが、Chrome のセキュリティ上の制限でフォーカスをどうしても当てられないようです。
window.focus() を無効にしてる？ Chrome 内で foreground にするだけのようです。
