### PR TITLE
Add opt.multipart to use multipart/form-data without a file

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -782,7 +782,7 @@ function request(url, opt) {
   }
 
   // construct FormData (if required)
-  var multipart = false;
+  var multipart = opt.multipart || false;
   if (opt.sendContent && opt.mode && (opt.mode === 'raw')) {
     // no modify, use sendContent directly
     data = opt.sendContent;


### PR DESCRIPTION
レアなケースではありますが、File が無い場合でも強制的に multipart/form-data を利用できる用にオプションを追加しました。

form に multipart/form-data が指定されていた場合で、file エレメントが無い場合。
例)
二次元画像詳細検索
http://www.ascii2d.net/imagesearch
