### PR TITLE
Form.resize() shouldn't work in Browser Action's QuickPostForm

### DIFF
--- a/src/lib/popup.js
+++ b/src/lib/popup.js
@@ -306,6 +306,9 @@ Form.shortcutkeys[KEY_ACCEL + ' + RETURN'] = function(){
 };
 
 Form.resize = function() {
+  if (isPopup) {
+    return;
+  }
   if(!Form.nowResizing){
     Form.nowResizing = true;
     var root = document.body;


### PR DESCRIPTION
775fe9024e53e7a2bdc673d53e0c571e1785ce4c により、ブラウザーのウィンドウを最大化している時にBrowser ActionのQuickPostFormを開くと最大化が解除されてしまう不具合が発生していたので、Browser ActionのQuickPostFormでは`Form.resize()`が実行されても、この状況下では不要であるはずのQuickPostFormのresize処理を行わないように変更しました。

不具合及びこの変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 26.0.1410.64、拡張のバージョンは2.0.79-dev( 17f10475c564997740a6562888dd64f777d795ba までの変更を含む)という環境で確認しています。
