### PR TITLE
Implement "Not enqueue in case of Reblog" option #43

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -48,6 +48,9 @@
   "label_postWithQueue": {
     "message": "Tumblr - Post with Queue"
   },
+  "label_notQueueReblogPost": {
+    "message": "Not enqueue in case of Reblog"
+  },
   "label_alwaysShortenURL": {
     "message": "Twitter - Always Shorten URL"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -48,6 +48,9 @@
   "label_postWithQueue": {
     "message": "Tumblr - キューに入れてポストする"
   },
+  "label_notQueueReblogPost": {
+    "message": "Reblogの場合はキューに入れない"
+  },
   "label_alwaysShortenURL": {
     "message": "Twitter - 常にURLを短縮する"
   },

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -214,7 +214,12 @@ var Tumblr = {
     form['post[state]'] = (ps.private) ? 'private' : '0';
     if (TBRL.Config.post['post_with_queue']) {
       if (ps.type !== 'regular') {
-        form['post[state]'] = 2;
+        if (!(
+          TBRL.Config.post['not_queue_reblog_post'] &&
+            ps.favorite && ps.favorite.name === 'Tumblr'
+        )) {
+          form['post[state]'] = 2;
+        }
       }
     }
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -51,6 +51,7 @@ connect(document, 'onDOMContentLoaded', document, function(){
   $('label_tagAutoComplete').appendChild($T(chrome.i18n.getMessage('label_tagAutoComplete')));
   $('label_notificationOnPosting').appendChild($T(chrome.i18n.getMessage('label_notificationOnPosting')));
   $('label_postWithQueue').appendChild($T(chrome.i18n.getMessage('label_postWithQueue')));
+  $('label_notQueueReblogPost').appendChild($T(chrome.i18n.getMessage('label_notQueueReblogPost')));
   $('label_alwaysShortenURL').appendChild($T(chrome.i18n.getMessage('label_alwaysShortenURL')));
   $('label_clipFullPage').appendChild($T(chrome.i18n.getMessage('label_clipFullPage')));
   $('label_removeHatenaKeyword').appendChild($T(chrome.i18n.getMessage('label_removeHatenaKeyword')));
@@ -121,6 +122,15 @@ connect(document, 'onDOMContentLoaded', document, function(){
 
   // Post with Queue
   var queue_check = new Check('post_with_queue', !!Config.post['post_with_queue']);
+  // Post with Queue
+  var not_queue_reblog_post_check = new Check('not_queue_reblog_post', !!Config.post['not_queue_reblog_post']);
+  if (!queue_check.body()) {
+    $('not_queue_reblog_post_checkbox').disabled = true;
+  }
+  $('post_with_queue_checkbox').addEventListener('change', function(){
+    $('not_queue_reblog_post_checkbox').disabled = !$('not_queue_reblog_post_checkbox').disabled;
+  });
+
   // Shorten URL
   var shorten_check = new Check('always_shorten_url', !!Config.post['always_shorten_url']);
   // Evernote - Clip Full Page
@@ -211,6 +221,7 @@ connect(document, 'onDOMContentLoaded', document, function(){
           "always_shorten_url" : shorten_check.body(),
           "multi_tumblelogs"   : tcheck,
           "post_with_queue"    : queue_check.body(),
+          "not_queue_reblog_post": not_queue_reblog_post_check.body(),
           "enable_google_plus_pages" : gcheck,
           'taberareloo_on_google_plus' : enableGooglePlusKey_check.body(),
           "shortcutkey_taberareloo_on_google_plus" : googlePlusKey_short.body(),

--- a/src/options.html
+++ b/src/options.html
@@ -75,6 +75,7 @@
       </div>
       <div class="option">
         <p id="label_postWithQueue"></p><input id="post_with_queue_checkbox" type="checkbox" name="post_with_queue">
+        <p id="label_notQueueReblogPost"></p><input id="not_queue_reblog_post_checkbox" type="checkbox" name="not_queue_reblog_post">
       </div>
       <div class="option">
         <p id="label_alwaysShortenURL"></p><input id="always_shorten_url_checkbox" type="checkbox" name="always_shorten_url">


### PR DESCRIPTION
#43、及び[コミュニティ](https://plus.google.com/108720151724524871327/posts/PhBtwwZh75i)の方で提案された、「Reblogの場合はキューに入れない」設定を実装しました。

この変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 26.0.1410.64、拡張のバージョンは2.0.79-dev( 17f10475c564997740a6562888dd64f777d795ba までの変更を含む)という環境で確認しています。
