### PR TITLE
Improve Tumblr ReBlog Extractors

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -593,7 +593,7 @@ Extractors.register([
       }
 
       var matches = doc.body.textContent.match(/document\.write\('<iframe src="(http:\/\/(www|assets)\.tumblr\.com\/iframe[^"]+)" width=/);
-      if (matches) {
+      if (matches && queryHash(matches[1]).pid) {
         return matches[1];
       }
 


### PR DESCRIPTION
[YungSangさんとのコミュニティでの議論](https://plus.google.com/109448778834120388056/posts/CYY9vVX4FYP)や[パッチ](https://github.com/YungSang/patches-for-taberareloo/blob/master/patches/patch.tumblr.getform.tbrl.js)を参考に、TumblrのReBlogに関するExtractorの改善を行いました。
「長文を含むTextポストをLinkポストに変換しない」が有効になっていて且つDashboardからTextポストをReblogしようとした時、そのポストがTextポストである事をDashboard上に存在する情報から確認する事で、Tumblrとの通信がこれまでより一つ減少します。
また、 8b45f6f1b62685922d1d6b44e672db6cdd5b9a36 で、ユーザーのTumblrのポストが並んだインデックスページなどで、リンクからポストをReblogしようとしてもできないというRegressionが発生してしまっていたので修正しました。

この変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 26.0.1410.64、拡張のバージョンは2.0.79-dev( c4a8d085dec49d641c5dcce24bf768c3e6a97a0d までの変更を含む)という環境で確認しています。
