### PR TITLE
Refollow the changes of Tumblr Dashboard iframe

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -608,7 +608,7 @@ Extractors.register([
 
       var url = doc.body.textContent.extract(/(?:<|\\x3c)iframe\b[\s\S]*?src\s*=\s*(["']|\\x22)(http:\/\/(?:www|assets)\.tumblr\.com\/.*?iframe.*?)\1/i, 2);
       if (queryHash(url).pid) {
-        return url.replace(/\\x22/g, '"').replace(/\\x26/g, '&');
+        return url.replace(/\\x26/g, '&');
       }
 
       return '';


### PR DESCRIPTION
#186 に続いてまたも[TumblrのDashboard iframeに関して変更が行われつつある](https://plus.google.com/109448778834120388056/posts/VA2M7TzRjrX)ので、[polygonplanetさんのパッチ](https://github.com/polygonplanet/tombloo/blob/ec1716b0cdbcc2a3098e5827faa22b9f2f072283/tombloo.extractor.tumblr.reblog.fix.js)を参考にして、ReBlog Extractorの`getFrameUrl`関数をその変更に対応させました。影響範囲は、#198 における変更により「ReBlog - Dashboard」Extractorは含まれず、主に「ReBlog - Tumblr」Extractor、「ReBlog - Tumblr link」Extractorが該当します。

また、ReBlog Extractorの`extractByPage`関数から`getFrameUrl`関数を呼び出した際、Dashboard iframeからReblogに必要な情報が取得できない場合は、[Tumblr API v1](http://www.tumblr.com/docs/en/api/v1)から取得するようにしました。独自ドメインの場合は、そのページがTumblrのサイトであるかこの段階ではURL以外で判別できる要素が見当たらない為、適用対象から外しています。

不具合及びこの変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 26.0.1410.64、拡張のバージョンは3.0.1-dev( 5e540e44f3b8d85ea1ec1226c625d734524f659e までの変更を含む)という環境で確認しています。
