### PR TITLE
Update "Play on Tumblr"

### DIFF
--- a/src/lib/userscripts.js
+++ b/src/lib/userscripts.js
@@ -4,7 +4,7 @@
 /*global Keybind:true, get_active_feed:true, get_active_item:true*/
 /*global $X:true, createFlavoredString:true, update:true, Extractors:true*/
 /*global $N:true, Deferred:true, keyString:true, stop:true, Tumblr:true*/
-/*global tagName:true, MochiKit:true*/
+/*global tagName:true, MochiKit:true, MouseEvent:true*/
 (function (exports) {
   'use strict';
 
@@ -533,31 +533,79 @@
       }
     },
     play : function (current) {
-      var small = !!$X('.//img[contains(@class, "image_thumbnail")]', current)[0];
-      if (small) {
-        var img = $X('.//div[starts-with(@id, "highres_photo")]', current)[0];
-        if (img) {
-          if (img.style.display !== 'none') {
-            $X('./a', img)[0].click();
-          } else {
-            $X('./preceding-sibling::a[1]', img)[0].click();
-          }
-          return;
-        }
-      }
-      if ($X('.//div[contains(@id, "watch_") and .//a]', current).some(function (mov) {
-        if (mov.style.display !== 'none') {
-          $X('.//a', mov)[0].click();
-          return true;
-        }
-        return false;
-      })) {
+      // quit photoset lightbox or panorama lightbox
+      var lightbox = document.body.querySelector('#tumblr_lightbox, .pano_lightbox');
+      if (lightbox) {
+        lightbox.click();
         return;
       }
-      if (small) {
-        $X('.//img[contains(@src, "media.tumblr.com/tumblr_")]', current).forEach(function (timg) {
-          timg.click();
-        });
+
+      // for photo(not full size) post, inline image
+      var small_image = current.querySelector(
+        '.image_thumbnail, .constrained_image'
+      );
+      if (small_image) {
+        small_image.click();
+      }
+
+      var data = current.dataset;
+
+      // for Tumblr uploaded audio post
+      if (data.type === 'audio') {
+        var audio_player_overlay = current.querySelector('.audio_player_overlay');
+        if (audio_player_overlay) {
+          audio_player_overlay.dispatchEvent(new MouseEvent('mousedown'));
+        }
+        return;
+      }
+
+      // for Tumblr uploaded video post
+      if (data.type === 'video' && data.directVideo === '1') {
+        var tumblr_video_iframe = current.querySelector('.tumblr_video_iframe');
+
+        if (tumblr_video_iframe) {
+          var contentDocument = tumblr_video_iframe.contentDocument;
+          if (contentDocument) {
+            var tumblr_video_player = contentDocument.querySelector('.tumblr_video_player');
+            if (!tumblr_video_player) {
+              return;
+            }
+
+            // toggle video playing and video lightbox launching
+            if (current.classList.contains('is_lightbox')) {
+              var tvp_pause_button = tumblr_video_player.querySelector('.tvp_pause_button');
+              if (tvp_pause_button) {
+                tvp_pause_button.click();
+              }
+              var close_button = current.querySelector('.close_button');
+              if (close_button) {
+                close_button.click();
+              }
+            } else {
+              var tvp_play_button = tumblr_video_player.querySelector('.tvp_play_button');
+              var init = tumblr_video_player.classList.contains('init');
+              if (tvp_play_button) {
+                tvp_play_button.click();
+              }
+              if (init) {
+                var tvp_fullscreen_button = tumblr_video_player.querySelector('.tvp_fullscreen_button');
+                if (tvp_fullscreen_button) {
+                  tvp_fullscreen_button.click();
+                }
+              }
+            }
+          }
+        }
+
+        return;
+      }
+
+      // for photoset, panorama, link, video post.
+      var target = current.querySelector(
+        '.photoset_photo, .panorama, .link_title, .big_play_button'
+      );
+      if (target) {
+        target.click();
       }
     },
     like : function (current) {


### PR DESCRIPTION
[コミュニティ](https://plus.google.com/108720151724524871327/posts/FDET3kHC6SH)の方で報告された「Play on Tumblr」が正常に動作していない問題を解決する為に実装を更新しました。以下の通り、主に2つの変更を行いました。
1. 「Play on Tumblr」と[公式のキーボードショートカット](http://www.tumblr.com/tips#keyboard_shortcuts)が競合する問題を修正しました。公式と同じキーを設定した場合、これからはTaberarelooの「Play on Tumblr」の設定が優先されます。コードに関しては、[Mozilla Japanの中野さんの記事](http://www.d-toybox.com/studio/weblog/show.php?mode=single;id=2012021100)が参考になるでしょう。  
   今、[公式のキーボードショートカットのページのはてなブックマーク](http://b.hatena.ne.jp/entry/www.tumblr.com/tips%23keyboard_shortcuts)を見てみたところ、ちょうど最近にこの問題に関して言及があったようですね。
2. これまでTaberarelooの「Play on Tumblr」の「Play」は、[Tumblrの設定ページ](https://www.tumblr.com/settings/dashboard)で「Show full size photos」を有効にしていた場合にPhotoポストの縮小された画像を拡大したり、Videoポストの動画を再生したり、Textポストなどに含まれるインラインの画像を表示・拡大したりといった機能があったようですが、これらの対応を更新すると共に、新たにPhotoset、[Panorama](http://staff.tumblr.com/post/40779375054/panoramas)、Link、Audioポストにも対応するように変更しました。Linkポストの場合はリンクを新しいタブに開くようになります。また、AudioポストはTumblrにアップロードされた音楽ファイルを再生するプレーヤーにのみ対応し、SoundCloudやSpotifyのプレーヤーには対応していません。  
   Tumblrにアップロードされた動画に関するVideoポストへの対応は、動画を再生する場合はLightboxも表示し、停止する場合はLightboxも止める、という実装にした為、やや複雑になってしまったかもしれません。まだ改善の余地がありそうです。

コミュニティの方で問題を確認した際、公式のキーボードショートカットの「Play」に相当するスペースキーでは縮小された画像の拡大ができなかったので、こちらも正常に動作していないのではと思っていたのですが、[Tumblrにおける実装](http://assets.tumblr.com/assets/scripts/dashboard.js)を確認したところ、もともとPhotoset、Videoポストのみの対応になっていたようです。
また、[Keyconfig](https://chrome.google.com/webstore/detail/empty-title/okneonigbfnolfkmfgjmaeniipdjkgkl)とのLDRizeによる連携も確認しましたが(「Play on Tumblr」は公式のキーボードショートカットによりKeyconfigなしでも使用できます)、PanoramaポストのLightboxを止めるとJ、Kキーによるポスト間移動が正常にできなくなるという問題があるようです。この問題の原因がTaberarelooにあるのかKeyconfigにあるのかTumblrにあるのかは良くわかりませんでした。

最初は、公式でキーボードショートカットが利用できるようになった以上、もはや「Play on Tumblr」の役割は終わりつつあり、将来的には「Play on Tumblr」は削除した方が良いと思っていたのですが、実装を更新する際にKeyconfigとの連携についても考えてみたところ、TumblrのDashboardにおいてTaberarelooとKeyconfigが連携する際は、Keyconfigの動作の都合上、現状ではTaberarelooの「Disable Tumblr default keybind」を有効にする必要があるので、公式のキーボードショートカットの「Play」、「Like」、「ReBlogCount」は利用できなくなります。上記の2のように「Play」に関してはTaberarelooで取り組める事も残っているようですので、これからも「Play on Tumblr」の実装を維持していく必要があるようです。

不具合及びこの変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 26.0.1410.64、拡張のバージョンは3.0.2-dev( 28644af6872eebbfd37dc00bcba975917397dcf7 までの変更を含む)という環境で確認しています。
