### PR TITLE
Follow Tumblr Dashboard changes

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -698,7 +698,7 @@
         return (/(tumblr-beta\.com|tumblr\.com)\//).test(ctx.href) && this.getLink(ctx);
       },
       extract : function (ctx) {
-        var post = $X('./ancestor-or-self::li[starts-with(@id, "post_")]', ctx.target)[0];
+        var post = $X('./ancestor-or-self::div[starts-with(@id, "post_")]', ctx.target)[0];
 
         if (post) {
           var data = post.dataset;
@@ -714,7 +714,7 @@
       },
       getLink : function (ctx) {
         var link = $X(
-          './ancestor-or-self::li[starts-with(normalize-space(@class), "post")]//a[starts-with(@id, "permalink_")]', ctx.target)[0];
+          './ancestor-or-self::div[starts-with(@id, "post_")]//a[starts-with(@id, "permalink_")]', ctx.target)[0];
         return link && link.href;
       }
     },

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -198,7 +198,7 @@ var Tumblr = {
       if($X('id("logged_out_container")', doc)[0])
         throw new Error(chrome.i18n.getMessage('error_notLoggedin', that.name));
 
-      form.form_key = Tumblr.form_key = $X('id("form_key")/@value', doc)[0];
+      form.form_key = Tumblr.form_key = $X('//input[@name="form_key"]/@value', doc)[0];
       form.channel_id = Tumblr.channel_id = $X('//input[@name="t"]/@value', doc)[0];
 
       return form;
@@ -340,7 +340,7 @@ var Tumblr = {
       var doc = res.response;
       if($X('id("logged_out_container")', doc)[0])
         throw new Error(chrome.i18n.getMessage('error_notLoggedin', self.name));
-      return self.token = $X('id("form_key")/@value', doc)[0];
+      return self.token = $X('//input[@name="form_key"]/@value', doc)[0];
     });
   },
 

--- a/src/lib/userscripts.js
+++ b/src/lib/userscripts.js
@@ -268,7 +268,7 @@
         document.addEventListener('keydown', this.wrap, false);
       },
       getCurrentItem: function () {
-        var paragraphs = $X('id("posts")/li[starts-with(@id, "post") or starts-with(@id, "tweet")]'), toplist = new Array(paragraphs.length);
+        var paragraphs = $X('id("posts")/li/div[starts-with(@id, "post_")]'), toplist = new Array(paragraphs.length);
         var get_top = function (index) {
           return toplist[index] || (toplist[index] = paragraphs[index].getBoundingClientRect().top);
         };
@@ -609,13 +609,13 @@
       }
     },
     like : function (current) {
-      var like = current.querySelector('.like_button');
+      var like = current.querySelector('.like');
       if (like) {
         like.click();
       }
     },
     reblogCount: function (current) {
-      var count = current.querySelector('.reblog_count');
+      var count = current.querySelector('.post_notes_label');
       if (count) {
         count.click();
       }


### PR DESCRIPTION
[TumblrのDashboardで行われつつある変更](https://plus.google.com/109448778834120388056/posts/K9fpvnXv4qb)に伴い、Tumblr Model、「ReBlog - Dashboard」 Extractor、「Play on Tumblr」、「Dashboard + Taberareloo」を更新しました。`form_key`の取得方法の違いにより、複数タンブルログ有効時に、ポストはできる状態になっているようです。

不具合及びこの変更の動作は、Windows 7 Home Premium SP1 64bit上のChrome 27.0.1453.94、拡張のバージョンは3.0.2-dev( c38d743e803e539d476dcfa9657fc6908828c72b までの変更を含む)という環境で確認しています。
