### PR TITLE
Fix a bug that patches won't be loaded on pre-rendering sites.

### DIFF
--- a/src/lib/background.js
+++ b/src/lib/background.js
@@ -513,6 +513,12 @@
     }
   };
 
+  chrome.tabs.onReplaced.addListener(function (new_tab_id, old_tab_id) {
+    chrome.tabs.get(new_tab_id, function (tab) {
+      Patches.loadInTab(tab);
+    });
+  });
+
   chrome.runtime.onMessage.addListener(function (req) {
     var handler = onRequestsHandlers[req.request];
     if (handler) {


### PR DESCRIPTION
「ネットワーク動作を予測してページの表示速度を向上させる」を有効にしていた場合に
検索結果のトップのページが「事前レンダリング」(pre-rendering)されますが、
その時に、コンテンツスクリプトのロードが行われるにも関わらず、パッチのロードが失敗します。
(裏でタブIDは振られるが、実際には chrome.tabs.executeScript で該当するタブが存在しないエラー)

「事前レンダリング」された隠れタブが実際にタブとして表示された時にパッチの再ロードを試みるようにしました。

よろしくお願いします。

参考：
https://plus.google.com/109448778834120388056/posts/LFh6V7tsKbh
http://developer.chrome.com/extensions/tabs.html#event-onReplaced
