### PR TITLE
Add setRequestHandler function

### DIFF
--- a/src/lib/background.js
+++ b/src/lib/background.js
@@ -377,6 +377,9 @@
 
     isBackground: function () {
       return true;
+    },
+    setRequestHandler : function (request, handler) {
+      onRequestsHandlers[request] = handler;
     }
   };
 

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -328,6 +328,9 @@
 
     isBackground: function () {
       return false;
+    },
+    setRequestHandler: function (request, handler) {
+      onRequestHandlers[request] = handler;
     }
   };
 


### PR DESCRIPTION
今までパッチの中で独自に chrome.runtime.onMessage.addListener を使ってセットしていましたが、
複数登録した際の動作が不安定なのと、

https://developer.chrome.com/dev/extensions/runtime.html#event-onMessage
If you have more than one onMessage listener in the same document, then only one may send a response.

ということもあり、関数を用意した方が良いのではないかと思っていました。

もしかしたら、TBRL.setRequestHandler の方が良かったかも知れません。

addMessageListener の名前も考えたのですが、add と言うわけではなくて上書きする場合もあるので、set にし、
現行の onRequestsHandlers オブジェクトにセットする形なので現状を理解しやすい名前にしてみました。

よろしくお願いします。
