### PR TITLE
Change getViewDimensions -> getViewportDimensions for the future use

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -4,7 +4,7 @@
 /*global Deferred:true, queryHash:true, unescapeHTML:true, queryString:true*/
 /*global joinText:true, getStyle:true, tagName:true, downloadFile:true*/
 /*global getFileExtension:true, getElementDimensions:true*/
-/*global getViewportPosition:true, getViewportDimensions:true*/
+/*global getViewportDimensions:true*/
 /*global getPageDimensions:true, base64ToFileEntry:true, MochiKit:true*/
 /*global cancel:true, keyString:true, setElementPosition:true*/
 /*global $D:true, $T:true, setStyle:true, setElementDimensions:true*/
@@ -1415,7 +1415,7 @@
             });
 
           case 'View':
-            return self.capture(win, getViewportPosition(), getViewportDimensions());
+            return self.capture(win, { x: 0, y: 0 }, getViewportDimensions());
 
           case 'Page':
             return self.capture(win, { x: 0, y: 0 }, getPageDimensions());


### PR DESCRIPTION
typo なのか、削除されてしまった関数なのかわかりませんが、
https://github.com/YungSang/patches-for-taberareloo/blob/master/others/menu.capture.window.tbrl.js
で試してみたら、上手く行ったので修正しました。

なお、
'Page' の方も

```
          return self.capture(win, { x : 0, y : 0 }, {
            w : document.width || document.body.offsetWidth,
            h : document.height || document.body.offsetHeight
          });
```

で試してみましたが、viewport にのみ有効なようで、全体を Capture するには、スクロールさせつつ、
captureVisibleTab を使って、継ぎ足して一つの画像にする必要があるようです。
