### PR TITLE
Must not overwrite ps.item with ps.page, even if ps.item is null

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -1616,7 +1616,6 @@ Models.register({
     var maxlen   = 140;
     if (ps.type === 'photo') {
       ps = update({}, ps);
-      ps.item    = ps.page;
       ps.itemUrl = ps.pageUrl;
       maxlen -= 23; // reserve for pic.twitter.com
     }


### PR DESCRIPTION
“TaberarelooでTwitterに投げるとき元記事のタイトルとか削っても復活するの何なんだ”
https://plus.google.com/109448778834120388056/posts/59aU9erKpr6

に対応しました。
