### PR TITLE
Avoid errors on pre-rendering and redirection

### DIFF
--- a/src/lib/background.js
+++ b/src/lib/background.js
@@ -561,13 +561,17 @@
       Models['Google+'].removeCommunityCategory(ps.pageUrl, ps.page);
     },
     loadPatchesInContent: function (req, sender) {
-      Patches.loadInTab(sender.tab);
+      if (req.visibility !== 'prerender') { // if (sender.tab.index !== -1) {
+        Patches.loadInTab(sender.tab);
+      }
     }
   };
 
   chrome.tabs.onReplaced.addListener(function (new_tab_id, old_tab_id) {
     chrome.tabs.get(new_tab_id, function (tab) {
-      Patches.loadInTab(tab);
+      if (tab.index !== -1) {
+        Patches.loadInTab(tab);
+      }
     });
   });
 

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -622,7 +622,8 @@
 
   // Start patch
   chrome.runtime.sendMessage(TBRL.id, {
-    request: 'loadPatchesInContent'
+    request: 'loadPatchesInContent',
+    visibility: document.webkitVisibilityState
   }, function () {});
 
   exports.TBRL = TBRL;

--- a/src/lib/patch.js
+++ b/src/lib/patch.js
@@ -322,8 +322,11 @@
           self.readFromFileEntry(patch.fileEntry).addCallback(function (script) {
             chrome.tabs.executeScript(tab.id, {
               code : script
-            }, function () {});
-            console.log('Load patch in ' + tab.url + ' : ' + patch.fileEntry.fullPath);
+            }, function (result) {
+              if (typeof result !== 'undefined') {
+                console.log('Load patch in ' + tab.url + ' : ' + patch.fileEntry.fullPath);
+              }
+            });
           });
         }
       });


### PR DESCRIPTION
大きな問題では無いのですが、pre-rendering の時にパッチのロードをしないように修正しました。
また、パッチの実行に成功した時のみ、パッチのロード・メッセージを出すようにしました。

なお、redirection の場合のエラーは事前に回避不可能と思われます。

調査内容は https://github.com/Constellation/taberareloo/pull/222 のコメントで。
