### PR TITLE
Fix Repository.register to replace an old one correctly, in case a new one is inserted before the old one.

### DIFF
--- a/src/lib/repository.js
+++ b/src/lib/repository.js
@@ -65,6 +65,11 @@
         return;
       }
       defs = [].concat(defs);
+      defs.forEach(function (d) {
+        if (this.hasOwnProperty(d.name)) {
+          this.remove(this[d.name]);
+        }
+      }, this);
       if (target) {
         var vals = this.values;
         this.clear();
@@ -77,9 +82,6 @@
         defs = vals;
       }
       defs.forEach(function (d) {
-        if (this.hasOwnProperty(d.name)) {
-          this.remove(this[d.name]);
-        }
         this.list.push(d);
         this[d.name] = d;
       }, this);


### PR DESCRIPTION
同名のオブジェクトをパッチから上書き登録しようとした際、
挿入先の target の位置が既存のオブジェクトより先にあった場合(同じ位置に追加しようとした場合)に、
新しいオブジェクトの方が削除されてしまっていました。
必ず先に既存のオブジェクトを削除してから追加するように変更しました。
