### PR TITLE
Fix a bug on Tumblr IDs which have the main blog ID as a prefix

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -370,7 +370,7 @@ var Tumblr = {
       Tumblr.blogs = [Tumblr.channel_id];
       return Array.prototype.slice.call(doc.querySelectorAll(
         '#popover_blogs .popover_menu_item ' +
-          'a[href^="/blog/"]:not([href^="/blog/' + Tumblr.channel_id + '"])'
+          'a[href^="/blog/"]:not([href="/blog/' + Tumblr.channel_id + '"])'
       )).reverse().map(function(a){
         var id = a.getAttribute('href').replace(/^\/blog\//g, '');
         Tumblr.blogs.push(id);


### PR DESCRIPTION
メインのIDと同じ文字列が含まれるサブブログの取得に失敗していました。
