### PR TITLE
Fix the first click right after capturing

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -1345,6 +1345,7 @@
           doc.removeEventListener('mouseout', onMouseOut, true);
           doc.removeEventListener('click', onClick, true);
           doc.removeEventListener('keydown', onKeyDown, true);
+          doc.removeEventListener('contextmenu', onClick, true);
 
           unpoint(target);
         }
@@ -1353,6 +1354,7 @@
         doc.addEventListener('mouseout', onMouseOut, true);
         doc.addEventListener('click', onClick, true);
         doc.addEventListener('keydown', onKeyDown, true);
+        doc.addEventListener('contextmenu', onClick, true);
 
         return deferred;
       },


### PR DESCRIPTION
- キャプチャのエリア選択後の最初のクリックが無効になっていました。
- キャプチャのエレメント選択時に右クリックでもキャンセル出来るようにしました。
