### PR TITLE
Fix to disable a click event on selectRegion

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -1569,7 +1569,6 @@
         }
 
         function finalize() {
-          doc.removeEventListener('click', onClick, true);
           doc.removeEventListener('mousedown', onMouseDown, true);
           doc.removeEventListener('mousemove', onMouseMove, true);
           doc.removeEventListener('mouseup', onMouseUp, true);


### PR DESCRIPTION
https://twitter.com/poochin/status/458750840887455744

例えばここ http://urasunday.com/moukin/comic/025_001.html
では画像をクリックすると次の画像へ移動するのですが、
キャプチャを選択して画像の上で mouse down、ドラッグ、そして同じ画像の上で mouse up すると、次の画像へ送られます。
