### PR TITLE
Fix chrome.tabs.captureVisibleTab on Chrome 34

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -112,7 +112,7 @@
    "default_locale": "en_US",
    "description": "Yet Another Tombloo on Chromium",
    "name": "Taberareloo",
-   "permissions": [ "http://*/*", "https://*/*", "tabs", "bookmarks", "contextMenus", "cookies", "unlimitedStorage", "notifications", "webRequest", "webRequestBlocking", "downloads" ],
+   "permissions": [ "<all_urls>", "tabs", "bookmarks", "contextMenus", "cookies", "unlimitedStorage", "notifications", "webRequest", "webRequestBlocking", "downloads" ],
    "version": "3.0.10",
    "incognito": "split"
 }


### PR DESCRIPTION
Chrome 側のバグかと思い修正されるのを待っていましたが、どうやら仕様変更だったようです。

chrome.tabs - Google Chrome
https://developer.chrome.com/extensions/tabs#method-captureVisibleTab
”You must have <all_urls> permission to use this method.”
