### PR TITLE
Fix Local model

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -653,7 +653,7 @@
 
     getDataURL : function (ps) {
       if (!ps.file) {
-        Promise.resolve(ps.itemUrl);
+        return Promise.resolve(ps.itemUrl);
       }
       return fileToDataURL(ps.file).then(function (url) { return url; });
     },


### PR DESCRIPTION
“アップデートしたtaberarelooで、画像のローカル保存の際にエラーが。自分だけかな。”﻿
https://plus.google.com/109448778834120388056/posts/YuaXfwd8yLD

以前から return が抜けていたようで、なぜ今回発覚したのか不明ですが、
これで問題は解決するようです。
