### PR TITLE
Revert the shortcut key for contextual post

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -25,7 +25,10 @@
     "message": "use Keyconfig instead ( if this is checked, Taberareloo doesn't observe key input. )"
   },
   "label_shortcutkey": {
-    "message": "Shortcutkey - $1 Quick Post"
+    "message": "Shortcutkey - $1 Post"
+  },
+  "label_shortcutkey_general": {
+    "message": "Shortcutkey - Contextual Post"
   },
   "label_clear": {
     "message": "clear"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -19,13 +19,16 @@
     "description": "Taberarelooについてのタブ"
   },
   "label_tagprovider": {
-    "message": "クイックポストで使うタグの取得元"
+    "message": "タグの取得元"
   },
   "label_keyconfig": {
     "message": "Keyconfig を使う ( チェックされているとTaberarelooによるキー監視は行われません )"
   },
   "label_shortcutkey": {
-    "message": "ショートカット - $1クイックポスト"
+    "message": "ショートカット - $1・ポスト"
+  },
+  "label_shortcutkey_general": {
+    "message": "ショートカット - コンテキスト・ポスト"
   },
   "label_clear": {
     "message": "クリア"

--- a/src/lib/background.js
+++ b/src/lib/background.js
@@ -17,7 +17,8 @@
       group: 'Taberareloo',
       actions: [
         {name: 'Taberareloo.link'},
-        {name: 'Taberareloo.quote'}
+        {name: 'Taberareloo.quote'},
+        {name: 'Taberareloo.general'}
       ]
     };
     chrome.runtime.sendMessage(CHROME_GESTURES, action, function () {
@@ -85,6 +86,7 @@
         'keyconfig': true,
         'shortcutkey_linkquickpost': '',
         'shortcutkey_quotequickpost': '',
+        'shortcutkey_quickpost': '',
         'evernote_clip_fullpage': true,
         'remove_hatena_keyword': false,
         'tumblr_default_quote': false,

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -129,6 +129,8 @@
     this.link_quick_short = new Shortcutkey('shortcutkey_linkquickpost', true);
     // shortcutkey quick link post
     this.quote_quick_short = new Shortcutkey('shortcutkey_quotequickpost', true);
+    // quick post
+    this.quick_short = new Shortcutkey('shortcutkey_quickpost', true);
 
     connect($('save'), 'onclick', this, this.save);
 
@@ -153,8 +155,10 @@
 
       $('label_shortcutkey_linkquickpost').appendChild($T(chrome.i18n.getMessage('label_shortcutkey', 'Link')));
       $('label_shortcutkey_quotequickpost').appendChild($T(chrome.i18n.getMessage('label_shortcutkey', 'Quote')));
+      $('label_shortcutkey_quickpost').appendChild($T(chrome.i18n.getMessage('label_shortcutkey_general')));
 
-      $('shortcutkey_linkquickpost_clear').value =
+      $('shortcutkey_quickpost_clear').value =
+        $('shortcutkey_linkquickpost_clear').value =
         $('shortcutkey_quotequickpost_clear').value =
         $('shortcutkey_ldr_plus_taberareloo_clear').value =
         $('shortcutkey_dashboard_plus_taberareloo_clear').value =
@@ -203,11 +207,12 @@
     save : function () {
       var lk = this.link_quick_short.body();
       var qk = this.quote_quick_short.body();
+      var k = this.quick_short.body();
       var tcheck = this.tumble_check.body();
       var enable_hatenablog = this.enableHatenaBlog_check.body();
       var enable_webhook = this.enable_webhook_check.body();
       var webhook_url = this.webhook_url_input.body();
-      if (!Shortcutkey.isConflict(lk, qk)) {
+      if (!Shortcutkey.isConflict(lk, qk, k)) {
         background.TBRL.configSet({
           'services' : this.services.body(),
           'post'     : {
@@ -234,6 +239,7 @@
             'tumblr_default_quote'  : this.tumblr_default_quote.body(),
             'shortcutkey_linkquickpost': lk,
             'shortcutkey_quotequickpost' : qk,
+            'shortcutkey_quickpost' : k,
             'always_shorten_url' : this.shorten_check.body(),
             'multi_tumblelogs'   : tcheck,
             'post_with_queue'    : this.queue_check.body(),

--- a/src/options.html
+++ b/src/options.html
@@ -55,6 +55,11 @@
       </div>
       <div class="option">
         <p id="label_keyconfig"></p><input id="keyconfig_checkbox" type="checkbox" name="keyconfig_checkbox">
+        <p id="label_shortcutkey_quickpost"></p>
+        <div>
+          <input id="shortcutkey_quickpost" type="text">
+          <input id="shortcutkey_quickpost_clear" type="button">
+        </div>
         <p id="label_shortcutkey_linkquickpost"></p>
         <div>
           <input id="shortcutkey_linkquickpost" type="text">


### PR DESCRIPTION
`ショートカット - クイックポスト` が無くなって不便になったとの声が散見されるので、
UI はそのままで、直接フォームを出すようにしてみました。
なかなか便利です。

また、用語を統一するために、オプション画面のラベルを一部変更しました。
でも、フォームのタイトルや変数、関数名はそのままにしてあります。
特に、KeyConfig のアクションは変更すると面倒なことになりそうなので、そのままです。
本当は general より contextual にしたいところでしたが。

https://github.com/Constellation/taberareloo/issues/265#issuecomment-50037519
