### PR TITLE
Use value for attribute instead of textContent

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -113,6 +113,7 @@
       case Node.ELEMENT_NODE:
         return node;
       case Node.ATTRIBUTE_NODE:
+        return node.value;
       case Node.TEXT_NODE:
         return node.textContent;
       }


### PR DESCRIPTION
'Attr.textContent' is deprecated. Please use 'value' instead.

まだ大丈夫そうですが、念の為。
