### PR TITLE
Fix an error on https://www.tumblr.com/

### DIFF
--- a/src/lib/extractors.js
+++ b/src/lib/extractors.js
@@ -353,7 +353,7 @@
 
     {
       name : 'ReBlog',
-      TUMBLR_URL : 'http://www.tumblr.com/',
+      TUMBLR_URL : 'https://www.tumblr.com/',
       extractByLink : function (ctx, link) {
         var that = this;
         return request(link, {responseType: 'document'}).then(function (res) {

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -19,7 +19,7 @@
     name : 'Tumblr',
     ICON : 'http://assets.tumblr.com/images/favicon.gif',
     MEDIA_URL : 'http://media.tumblr.com/',
-    TUMBLR_URL : 'http://www.tumblr.com/',
+    TUMBLR_URL : 'https://www.tumblr.com/',
     LINK : 'https://www.tumblr.com/',
     LOGIN_URL : 'https://www.tumblr.com/login',
 


### PR DESCRIPTION
Google Chrome Canary 38.0.2114.2 canary (64-bit) で https ページ上での http へのアクセスが制限されていた(厳しくなった？)ので、API の URL をhttps にしました。
extractor の方だけで良かったかも知れませんが、model の方も修正しました。
