### PR TITLE
Fix too small font size in Options

### DIFF
--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -60,7 +60,6 @@ div#inner {
   transition: margin-left 0.1s ease-out;
 }
 div.slide {
-  font-size: 80%;
   float: left;
   position: relative;
   display: inline;


### PR DESCRIPTION
設定内の文字サイズがいつの間にか小さくなっていたので修正しました。`font-size`が`10px`相当から`12px`相当に変化します。もしかすると、私の環境だけの現象で、他の環境では以前と変わっていないのかもしれませんが…。

![screenshot1](https://cloud.githubusercontent.com/assets/69238/4782415/1ed0751c-5cf1-11e4-892c-df144c72400a.PNG)
before

![screenshot2](https://cloud.githubusercontent.com/assets/69238/4782416/248408ca-5cf1-11e4-8000-2f66f9aefa52.PNG)
after

不具合及びこの変更の動作は、 Windows 7 Home Premium SP1 64bit 上の Chrome 38.0.2125.104(64-bit) 、拡張のバージョンは 4.0.4-dev ( e90ea7a3d034eecba955c4aafbb0fbd069637fde までの変更を含む)という環境で確認しています。
