### PR TITLE
Fix error handling on download error

### DIFF
--- a/src/lib/background.js
+++ b/src/lib/background.js
@@ -529,6 +529,11 @@
             content: e
           });
         });
+      }).catch(function (e) {
+        func({
+          success: false,
+          content: e
+        });
       });
     },
     notifications: function (req, sender, func) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -808,6 +808,8 @@
       var mime = res.getResponseHeader('Content-Type').replace(/;.*/, '');
       ext = getFileExtensionFromMime(mime) || ext;
       return createFileEntryFromBlob(res.response, ext);
+    }).catch(function (res) {
+      return res;
     });
   }
 


### PR DESCRIPTION
src/lib/content.js の downloadFile メソッドを使う、"Photo - Upload from Cache" などで、画面上に表示されていても、実際にはファイルがない場合などに、src/lib/utils.js の request メソッドからのエラーが、投げっぱなしジャーマンになってしまっていて、呼び出し元でエラーハンドリングできなかったのを修正。