### PR TITLE
Drop support for FriendFeed

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -19,7 +19,6 @@ Services example:
 +  Delicious
 +  Pinboard
 +  GoogleBookmarks
-+  FriendFeed
 +  Twitter
 +  Pocket
 +  Instapaper

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -1741,43 +1741,6 @@
   });
 
   Models.register({
-    name : 'FriendFeed',
-    ICON : 'https://friendfeed.com/favicon.ico',
-    LINK : 'https://friendfeed.com/',
-    LOGIN_URL : 'https://friendfeed.com/account/login',
-    check : function (ps) {
-      return (/photo|quote|link|conversation|video/).test(ps.type) && !ps.file;
-    },
-
-    getToken : function () {
-      var self = this;
-      return request('http://friendfeed.com/share/bookmarklet/frame', { responseType: 'document' })
-      .then(function (res) {
-        var doc = res.response;
-        if ($X('descendant::span[child::a[@href="http://friendfeed.com/account/login"]]', doc)[0]) {
-          throw new Error(chrome.i18n.getMessage('error_notLoggedin', self.name));
-        }
-        return $X('descendant::input[contains(concat(" ",normalize-space(@name)," ")," at ")]/@value', doc)[0];
-      });
-    },
-
-    post : function (ps) {
-      return this.getToken().then(function (token) {
-        return request('https://friendfeed.com/a/bookmarklet', {
-          //denyRedirection: true,
-          sendContent : {
-            at      : token,
-            link    : ps.pageUrl,
-            title   : ps.page,
-            image0  : ps.type === 'photo'? ps.itemUrl : '',
-            comment : joinText([ps.body, ps.description], ' ', true)
-          }
-        });
-      });
-    }
-  });
-
-  Models.register({
     name : 'Twitter',
     ICON : 'https://twitter.com/favicon.ico',
     URL  : 'https://twitter.com',


### PR DESCRIPTION
FriendFeed のサービス終了を確認しましたので、対応終了の変更を行いました。

>FriendFeed was shut down on April 9, 2015.

http://blog.friendfeed.com/2015/04/friendfeed-was-shut-down-on-april-9-2015.html

この変更の動作は、Windows 7 Home Premium SP1 64bit 上の Chrome 41.0.2272.118(64-bit)、拡張のバージョンは 4.0.5-dev( d4ef3ec245f8cd032d41d2b2fd460c6e21b7b377 までの変更を含む)という環境で確認しています。